### PR TITLE
update standings page

### DIFF
--- a/controllers/StandingsController.js
+++ b/controllers/StandingsController.js
@@ -44,7 +44,8 @@ const controller = {
     models.Week.current().then(wk => {
       Promise.join(models.Place.overall(uid, wk.id), models.Standing.overall(uid, wk.id), (tipping, goalmine) => {
         res.render('standings/index', {
-          title: 'Standings at Week' + wk.id,
+          title: 'Standings at Week ' + wk.id,
+          week: wk.id - 1,
           tipping: tipping,
           goalmine: goalmine
         })

--- a/models/places.js
+++ b/models/places.js
@@ -125,13 +125,13 @@ const places = (sequelize, DataTypes) => {
         let curr = models.sequelize.query(sql, { 
           replacements: { 
             start: start, 
-            end: wid },
+            end: wid - 1 },
           type: sequelize.QueryTypes.SELECT
         });
         let prev = models.sequelize.query(sql, { 
           replacements: { 
             start: start, 
-            end: wid - 1 },
+            end: wid - 2 },
           type: sequelize.QueryTypes.SELECT
         });
 

--- a/models/standings.js
+++ b/models/standings.js
@@ -60,13 +60,13 @@ const standings = (sequelize, DataTypes) => {
         let curr = models.sequelize.query(sql, { 
           replacements: { 
             start: start, 
-            end: wid },
+            end: wid - 1 },
           type: sequelize.QueryTypes.SELECT 
         });
         let prev = models.sequelize.query(sql, { 
           replacements: { 
             start: start, 
-            end: wid - 1 },
+            end: wid - 2 },
           type: sequelize.QueryTypes.SELECT 
         });
 

--- a/views/standings/index.hbs
+++ b/views/standings/index.hbs
@@ -1,5 +1,5 @@
 <section>
-  <h3>Standings</h3>
+  <h3>Standings for Week {{ week }}</h3>
   <div class="row justify-content-md-center">
     <div class="col-md-5">
     <h5>Goalmine</h5>


### PR DESCRIPTION
overall standings are now calculated for the week prior to the current week.
fixes a problem where if there are no matches for the current week the standings are not calculated correctly